### PR TITLE
Follow List Crash

### DIFF
--- a/src/components/home/searchResult.js
+++ b/src/components/home/searchResult.js
@@ -18,18 +18,18 @@ import firebase from 'react-native-firebase';
  *                   collection for the expected object properties.
  */
 class SearchResult extends React.PureComponent {
-  constructor(props){
+  constructor(props) {
     super(props);
     this._isMounted = false;
     this.unsubscribe = null;
     this.state = {
-      iconURL: ''
+      iconURL: '',
     };
   }
 
-  componentDidMount(){
+  componentDidMount() {
     this._isMounted = true;
-    if(this._isMounted){
+    if (this._isMounted) {
       //get the profile icon
       firebase
         .firestore()
@@ -37,25 +37,24 @@ class SearchResult extends React.PureComponent {
         .doc(this.props.uid)
         .get()
         .then((docSnapshot) => {
-          if(docSnapshot.exists) {
+          if (docSnapshot.exists) {
             const { icon } = docSnapshot.data();
-              this.state.iconURL = icon
-            console.log(this.state.iconURL)
-            console.log(icon)
-          }
-          else{
-            console.log("doesn't exist")
+            this.state.iconURL = icon;
+            console.log(this.state.iconURL);
+            console.log(icon);
+          } else {
+            console.log("doesn't exist");
           }
         })
         .catch((error) => {
           console.log(error);
         });
     }
-
   }
 
   render() {
     const { navigation, data, uid } = this.props;
+    if (!data || !uid) return null;
     return (
       <React.Fragment>
         <TouchableOpacity
@@ -63,7 +62,7 @@ class SearchResult extends React.PureComponent {
           style={styles.resultContainer}
         >
           <View>
-            <Image style={styles.profilePic} source={{uri: this.state.iconURL}} />
+            <Image style={styles.profilePic} source={{ uri: data.icon }} />
           </View>
           <View>
             <Text style={styles.primaryText}>{data.username}</Text>
@@ -96,7 +95,7 @@ const styles = StyleSheet.create({
     height: 50,
     width: 50,
     marginRight: '5%',
-    borderRadius: 50/2
+    borderRadius: 50 / 2,
   },
 });
 

--- a/src/components/home/searchResult.js
+++ b/src/components/home/searchResult.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Text, StyleSheet, TouchableOpacity, View, Image } from 'react-native';
 import { withNavigation } from 'react-navigation';
-
-const primePic = require('../../images/primePic.png');
 import firebase from 'react-native-firebase';
 
 /**
@@ -18,40 +16,6 @@ import firebase from 'react-native-firebase';
  *                   collection for the expected object properties.
  */
 class SearchResult extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this._isMounted = false;
-    this.unsubscribe = null;
-    this.state = {
-      iconURL: '',
-    };
-  }
-
-  componentDidMount() {
-    this._isMounted = true;
-    if (this._isMounted) {
-      //get the profile icon
-      firebase
-        .firestore()
-        .collection('Users')
-        .doc(this.props.uid)
-        .get()
-        .then((docSnapshot) => {
-          if (docSnapshot.exists) {
-            const { icon } = docSnapshot.data();
-            this.state.iconURL = icon;
-            console.log(this.state.iconURL);
-            console.log(icon);
-          } else {
-            console.log("doesn't exist");
-          }
-        })
-        .catch((error) => {
-          console.log(error);
-        });
-    }
-  }
-
   render() {
     const { navigation, data, uid } = this.props;
     if (!data || !uid) return null;


### PR DESCRIPTION
Fixes follow list crash when navigating from `profilePage` or `friendProfileScreen` to following/follower lists. `searchResult` now check is `this.props.data` is `null`, and returns null if it is.